### PR TITLE
Improve device name in sessions

### DIFF
--- a/Backend/Sources/Backend/TdHandler.swift
+++ b/Backend/Sources/Backend/TdHandler.swift
@@ -66,7 +66,7 @@ public extension TdApi {
                                         apiId: Secret.apiId,
                                         applicationVersion: SystemUtils.info(key: "CFBundleShortVersionString"),
                                         databaseDirectory: dir,
-                                        deviceModel: SystemUtils.deviceModel,
+                                        deviceModel: await SystemUtils.getDeviceModel(),
                                         enableStorageOptimizer: true,
                                         filesDirectory: dir,
                                         ignoreFileNames: false,

--- a/Utilities/Package.swift
+++ b/Utilities/Package.swift
@@ -13,10 +13,12 @@ let package = Package(
             name: "Utilities",
             targets: ["Utilities"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/mock-foundation/macmodels.git", from: "2022.07.12")
+    ],
     targets: [
         .target(
             name: "Utilities",
-            dependencies: [])
+            dependencies: [.product(name: "MacModels", package: "macmodels")])
     ]
 )


### PR DESCRIPTION
Now it's not just a device identifier, like `MacBookPro14,1`, but `MacBook Pro (13-inch, 2017, Two Thunderbolt 3 ports)` or instead of `Macmini9,1` it's `Mac mini (M1, 2020)`